### PR TITLE
Add support for `categories` resource

### DIFF
--- a/bigc/client.py
+++ b/bigc/client.py
@@ -4,6 +4,7 @@ from bigc.resources import *
 class BigCommerceAPI:
     def __init__(self, store_hash: str, access_token: str):
         self.carts: BigCommerceCartsAPI = BigCommerceCartsAPI(store_hash, access_token)
+        self.categories: BigCommerceCategoriesAPI = BigCommerceCategoriesAPI(store_hash, access_token)
         self.customers: BigCommerceCustomersAPI = BigCommerceCustomersAPI(store_hash, access_token)
         self.orders: BigCommerceOrdersAPI = BigCommerceOrdersAPI(store_hash, access_token)
         self.products: BigCommerceProductsAPI = BigCommerceProductsAPI(store_hash, access_token)

--- a/bigc/resources/__init__.py
+++ b/bigc/resources/__init__.py
@@ -1,4 +1,5 @@
 from .carts import BigCommerceCartsAPI
+from .categories import BigCommerceCategoriesAPI
 from .customers import BigCommerceCustomersAPI
 from .orders import BigCommerceOrdersAPI
 from .product_variants import BigCommerceProductVariantsAPI

--- a/bigc/resources/categories.py
+++ b/bigc/resources/categories.py
@@ -1,0 +1,33 @@
+from collections.abc import Iterator
+
+from bigc._client import BigCommerceV3APIClient
+
+
+class BigCommerceCategoriesAPI:
+    def __init__(self, store_hash: str, access_token: str):
+        self._v3_client = BigCommerceV3APIClient(store_hash, access_token)
+
+    def all(self) -> Iterator[dict]:
+        """Return an iterator for all categories"""
+        return self._v3_client.paginated_request('GET', '/catalog/categories')
+
+    def get(self, category_id: int) -> dict:
+        """Get a specific category by its ID"""
+        return self._v3_client.request('GET', f'/catalog/categories/{category_id}')
+
+    def create(self, *, name: str, is_visible: bool = True, parent_id: int = 0) -> dict:
+        """Create a category"""
+        payload = {
+            'name': name,
+            'is_visible': is_visible,
+            'parent_id': parent_id,
+        }
+        return self._v3_client.request('POST', '/catalog/categories', json=payload)
+
+    def update(self, category_id: int, data: dict) -> dict:
+        """Update a specific category by its ID"""
+        return self._v3_client.request('PUT', f'/catalog/categories/{category_id}', json=data)
+
+    def delete(self, category_id: int) -> dict:
+        """Delete a specific category by its ID"""
+        return self._v3_client.request('DELETE', f'/catalog/categories/{category_id}')


### PR DESCRIPTION
Support CRUD operations for BC `catalog/categories` resource. 

My Commands: 
``` python
bigc = BigCommerceCategoriesAPI('nice', 'try')
res_all = list(bigc.all())
res_get = bigc.get(24)
res_create = bigc.create(name='dillon')
res_update = bigc.update(category_id=29, data={'name':'dillon 10x', 'is_visible':False})
res_del = bigc.delete(29)
```
Responses:
![image](https://user-images.githubusercontent.com/42848484/173420615-48a97673-994e-4b08-a0d1-421321ac8301.png)
