### PR TITLE
Add support for querying batch product pricing

### DIFF
--- a/bigc/client.py
+++ b/bigc/client.py
@@ -8,6 +8,7 @@ class BigCommerceAPI:
         self.customer_groups: BigCommerceCustomerGroupsAPI = BigCommerceCustomerGroupsAPI(store_hash, access_token)
         self.customers: BigCommerceCustomersAPI = BigCommerceCustomersAPI(store_hash, access_token)
         self.orders: BigCommerceOrdersAPI = BigCommerceOrdersAPI(store_hash, access_token)
+        self.pricing: BigCommercePricingAPI = BigCommercePricingAPI(store_hash, access_token)
         self.products: BigCommerceProductsAPI = BigCommerceProductsAPI(store_hash, access_token)
         self.product_variants: BigCommerceProductVariantsAPI = BigCommerceProductVariantsAPI(store_hash, access_token)
         self.webhooks: BigCommerceWebhooksAPI = BigCommerceWebhooksAPI(store_hash, access_token)

--- a/bigc/resources/__init__.py
+++ b/bigc/resources/__init__.py
@@ -3,6 +3,7 @@ from .categories import BigCommerceCategoriesAPI
 from .customer_groups import BigCommerceCustomerGroupsAPI
 from .customers import BigCommerceCustomersAPI
 from .orders import BigCommerceOrdersAPI
+from .pricing import BigCommercePricingAPI
 from .product_variants import BigCommerceProductVariantsAPI
 from .products import BigCommerceProductsAPI
 from .webhooks import BigCommerceWebhooksAPI

--- a/bigc/resources/pricing.py
+++ b/bigc/resources/pricing.py
@@ -1,0 +1,18 @@
+from collections.abc import Iterator
+
+from bigc._client import BigCommerceV3APIClient
+
+
+class BigCommercePricingAPI:
+    def __init__(self, store_hash: str, access_token: str):
+        self._v3_client = BigCommerceV3APIClient(store_hash, access_token)
+
+    def products(self, customer_group_id: int, items: list[dict], channel_id: int = 1,
+                 currency_code: str = 'USD') -> Iterator[dict]:
+        """Return an iterator for batch product pricing"""
+        return self._v3_client.paginated_request('POST', '/pricing/products', json={
+            'customer_group_id': customer_group_id,
+            'items': items,
+            'channel_id': channel_id,
+            'currency_code': currency_code,
+        })


### PR DESCRIPTION
No issue assigned.

### Description

Adds support for querying batch product pricing as defined at: https://developer.bigcommerce.com/api-reference/92c669fa29742-get-prices-batch

Requires `customer_group_id` and `items` which is a list of objects specifying the items to price.
Optional parameters are `channel_id` which defaults to 1 for the default BC storefront ID, and `currency_code` which defaults to `USD`.