### PR TITLE
Fix TypeError in v3 API pagination

### DIFF
--- a/bigc/api_client.py
+++ b/bigc/api_client.py
@@ -158,7 +158,7 @@ class BigCommerceV3APIClient(BigCommerceRequestClient):
             query_dict['page'] = [str(cur_page)]
             paged_url_parts = url_parts._replace(query=urlencode(query_dict, doseq=True))
 
-            res_data = super().get(urlunparse(paged_url_parts), **kwargs)
+            res_data = super().request('GET', urlunparse(paged_url_parts), **kwargs)
 
             cur_page += 1
             num_pages = int(res_data['meta']['pagination']['total_pages'])


### PR DESCRIPTION
To get the enveloped response to get the page data, we use super(). However, super().get() calls self.request(), so we were getting the v3 implementation instead of the parent implementation.

Directly call super().request() to ensure we get the right implementation.