### PR TITLE
Let all_addresses optionally specify customer

### DIFF
--- a/bigc/resources/customers.py
+++ b/bigc/resources/customers.py
@@ -87,10 +87,11 @@ class BigCommerceCustomersAPI:
 
     def all_addresses(self, customer_id: Optional[int] = None) -> Iterator[dict]:
         """Get all addresses, optionally filtered by a customer's address book"""
-        if customer_id:
-            return self._api.v3.get_many(f'/customers/addresses?customer_id:in={customer_id}')
-        else:
-            return self._api.v3.get_many(f'/customers/addresses')
+        params = {
+            **({'customer_id:in': customer_id} if customer_id else {}),
+        }
+
+        return self._api.v3.get_many(f'/customers/addresses', params=params)
 
     def get_address(self, customer_id: int, address_id: int) -> dict:
         """Get one address by its ID, from a customer's address book"""

--- a/bigc/resources/customers.py
+++ b/bigc/resources/customers.py
@@ -85,9 +85,12 @@ class BigCommerceCustomersAPI:
         }]
         return self._api.v3.put('/customers/form-field-values', json=payload)[0]
 
-    def all_addresses(self, customer_id: int) -> Iterator[dict]:
-        """Get all addresses from a customer's address book"""
-        return self._api.v3.get_many(f'/customers/addresses?customer_id:in={customer_id}')
+    def all_addresses(self, customer_id: int | None = None) -> Iterator[dict]:
+        """Get all addresses, optionally filtered by a customer's address book"""
+        if customer_id:
+            return self._api.v3.get_many(f'/customers/addresses?customer_id:in={customer_id}')
+        else:
+            return self._api.v3.get_many(f'/customers/addresses')
 
     def get_address(self, customer_id: int, address_id: int) -> dict:
         """Get one address by its ID, from a customer's address book"""

--- a/bigc/resources/customers.py
+++ b/bigc/resources/customers.py
@@ -1,5 +1,5 @@
 from collections.abc import Iterator
-from typing import Any, Iterable
+from typing import Any, Iterable, Optional
 from urllib.parse import urlencode, urlparse, urlunparse
 
 from bigc.api_client import BigCommerceAPIClient
@@ -85,7 +85,7 @@ class BigCommerceCustomersAPI:
         }]
         return self._api.v3.put('/customers/form-field-values', json=payload)[0]
 
-    def all_addresses(self, customer_id: int | None = None) -> Iterator[dict]:
+    def all_addresses(self, customer_id: Optional[int] = None) -> Iterator[dict]:
         """Get all addresses, optionally filtered by a customer's address book"""
         if customer_id:
             return self._api.v3.get_many(f'/customers/addresses?customer_id:in={customer_id}')


### PR DESCRIPTION
Currently, `customers.all_addresses(...)` is written in a way such that you can only call it for a customer. However, BigCommerce does support retrieving all customer addresses for the store. We want this behavior for a migration so that we can make a single request for addresses, rather than `n = len(customers)` amount of requests.