### PR TITLE
Add include= kwarg to BigCommerceCheckoutsAPI

### DIFF
--- a/bigc/resources/checkouts.py
+++ b/bigc/resources/checkouts.py
@@ -1,5 +1,4 @@
-from typing import Union
-from urllib.parse import urlencode, urlparse, urlunparse
+from typing import Iterable, Union
 from uuid import UUID
 
 from bigc.api_client import BigCommerceAPIClient
@@ -11,81 +10,153 @@ class BigCommerceCheckoutsAPI:
     def __init__(self, api_client: BigCommerceAPIClient):
         self._api = api_client
 
-    def get(self, checkout_id: UUIDLike) -> dict:
+    def get(self, checkout_id: UUIDLike, *, include: Iterable[str] = ()) -> dict:
         """Get a specific checkout by its ID"""
-        return self._api.v3.get(f'/checkouts/{checkout_id}')
 
-    def update_customer_message(self, checkout_id: UUIDLike, *, customer_message: str) -> dict:
+        params = {}
+        if include:
+            params['include'] = ','.join(include)
+
+        return self._api.v3.get(f'/checkouts/{checkout_id}', params=params)
+
+    def update_customer_message(self,
+                                checkout_id: UUIDLike,
+                                *,
+                                customer_message: str,
+                                include: Iterable[str] = ()) -> dict:
         """Change customer message pertaining to an existing Checkout"""
+
+        params = {}
+        if include:
+            params['include'] = ','.join(include)
+
         payload = {'customer_message': customer_message}
-        return self._api.v3.put(f'/checkouts/{checkout_id}', json=payload)
 
-    def add_billing_address(self, checkout_id: UUIDLike, *, email: str, country_code: str, **kwargs) -> dict:
+        return self._api.v3.put(f'/checkouts/{checkout_id}', params=params, json=payload)
+
+    def add_billing_address(self,
+                            checkout_id: UUIDLike,
+                            *,
+                            email: str,
+                            country_code: str,
+                            include: Iterable[str] = (),
+                            **kwargs) -> dict:
         """Add a billing address to an existing checkout"""
-        payload = {'email': email, 'country_code': country_code, **kwargs}
-        return self._api.v3.post(f'/checkouts/{checkout_id}/billing-address', json=payload)
 
-    def update_billing_address(self, checkout_id: UUIDLike, address_id: str, *, email: str, country_code: str,
+        params = {}
+        if include:
+            params['include'] = ','.join(include)
+
+        payload = {
+            'email': email,
+            'country_code': country_code,
+            **kwargs
+        }
+
+        return self._api.v3.post(f'/checkouts/{checkout_id}/billing-address', params=params, json=payload)
+
+    def update_billing_address(self,
+                               checkout_id: UUIDLike,
+                               address_id: str,
+                               *,
+                               email: str,
+                               country_code: str,
+                               include: Iterable[str] = (),
                                **kwargs) -> dict:
         """Update an existing billing address on a checkout"""
-        payload = {'email': email, 'country_code': country_code, **kwargs}
-        return self._api.v3.put(f'/checkouts/{checkout_id}/billing-address/{address_id}', json=payload)
 
-    def add_consignment(self, checkout_id: UUIDLike,
-                        include_available_shipping_options: bool = False,
+        params = {}
+        if include:
+            params['include'] = ','.join(include)
+
+        payload = {
+            'email': email,
+            'country_code': country_code,
+            **kwargs
+        }
+
+        return self._api.v3.put(f'/checkouts/{checkout_id}/billing-address/{address_id}', params=params, json=payload)
+
+    def add_consignment(self,
+                        checkout_id: UUIDLike,
+                        include_available_shipping_options: bool = False,  # deprecated
+                        *,
+                        include: Iterable[str] = (),
                         **kwargs) -> dict:
         """Add a new consignment to a checkout"""
-        url_parts = urlparse(f'/checkouts/{checkout_id}/consignments')
 
-        include = []
+        # Compatibility code for include_available_shipping_options (deprecated)
         if include_available_shipping_options:
-            include.append('consignments.available_shipping_options')
+            include = [*include, 'consignments.available_shipping_options']
 
-        query_dict = {}
+        params = {}
         if include:
-            query_dict['include'] = ','.join(include)
-
-        url_parts = url_parts._replace(query=urlencode(query_dict))
+            params['include'] = ','.join(include)
 
         payload = [{**kwargs}]
-        return self._api.v3.post(urlunparse(url_parts), json=payload)
 
-    def update_consignment(self, checkout_id: UUIDLike, consignment_id: str,
-                           include_available_shipping_options: bool = False,
+        return self._api.v3.post(f'/checkouts/{checkout_id}/consignments', params=params, json=payload)
+
+    def update_consignment(self,
+                           checkout_id: UUIDLike,
+                           consignment_id: str,
+                           include_available_shipping_options: bool = False,  # deprecated
+                           *,
+                           include: Iterable[str] = (),
                            **kwargs) -> dict:
         """Update an existing consignment's selected shipping option"""
-        url_parts = urlparse(f'/checkouts/{checkout_id}/consignments/{consignment_id}')
 
-        include = []
+        # Compatibility code for include_available_shipping_options (deprecated)
         if include_available_shipping_options:
-            include.append('consignments.available_shipping_options')
+            include = [*include, 'consignments.available_shipping_options']
 
-        query_dict = {}
+        params = {}
         if include:
-            query_dict['include'] = ','.join(include)
-
-        url_parts = url_parts._replace(query=urlencode(query_dict))
+            params['include'] = ','.join(include)
 
         payload = {**kwargs}
-        return self._api.v3.put(urlunparse(url_parts), json=payload)
 
-    def delete_consignment(self, checkout_id: UUIDLike, consignment_id: str) -> dict:
+        return self._api.v3.put(f'/checkouts/{checkout_id}/consignments/{consignment_id}', params=params, json=payload)
+
+    def delete_consignment(self, checkout_id: UUIDLike, consignment_id: str, *, include: Iterable[str] = ()) -> dict:
         """Remove an existing consignment from a checkout"""
-        return self._api.v3.delete(f'/checkouts/{checkout_id}/consignments/{consignment_id}')
 
-    def add_coupon(self, checkout_id: UUIDLike, coupon_code: str) -> dict:
+        params = {}
+        if include:
+            params['include'] = ','.join(include)
+
+        return self._api.v3.delete(f'/checkouts/{checkout_id}/consignments/{consignment_id}', params=params)
+
+    def add_coupon(self, checkout_id: UUIDLike, coupon_code: str, *, include: Iterable[str] = ()) -> dict:
         """Add a coupon code to a checkout"""
+
+        params = {}
+        if include:
+            params['include'] = ','.join(include)
+
         payload = {'coupon_code': coupon_code}
-        return self._api.v3.post(f'/checkouts/{checkout_id}/coupons', json=payload)
 
-    def delete_coupon(self, checkout_id: UUIDLike, coupon_code: str) -> dict:
+        return self._api.v3.post(f'/checkouts/{checkout_id}/coupons', params=params, json=payload)
+
+    def delete_coupon(self, checkout_id: UUIDLike, coupon_code: str, *, include: Iterable[str] = ()) -> dict:
         """Delete a coupon code from a checkout"""
-        return self._api.v3.delete(f'/checkouts/{checkout_id}/coupons/{coupon_code}')
 
-    def add_discounts(self, checkout_id: UUIDLike, discounts: list) -> dict:
+        params = {}
+        if include:
+            params['include'] = ','.join(include)
+
+        return self._api.v3.delete(f'/checkouts/{checkout_id}/coupons/{coupon_code}', params=params)
+
+    def add_discounts(self, checkout_id: UUIDLike, discounts: list, *, include: Iterable[str] = ()) -> dict:
         """Add discounts to an existing checkout"""
+
+        params = {}
+        if include:
+            params['include'] = ','.join(include)
+
         payload = {'cart': {'discounts': discounts}}
-        return self._api.v3.post(f'/checkouts/{checkout_id}/discounts', json=payload)
+
+        return self._api.v3.post(f'/checkouts/{checkout_id}/discounts', params=params, json=payload)
 
     def create_order(self, checkout_id: UUIDLike) -> dict:
         """Create an order"""


### PR DESCRIPTION
From the [BigCommerce API docs](https://developer.bigcommerce.com/docs/rest-management/checkouts#get-a-checkout):

> `include` in `query` - string
> * `cart.line_items.physical_items.options` - physical options
> * `cart.line_items.digital_items.options` - digital options
> * `consignments.available_shipping_options` - shipping options
> * `promotions.banners` - promotion options

Rather than try to add a kwarg for each of these, instead we just have a single kwarg called `include`. You can pass it a list/tuple/etc. of strings, and it will join them and set them as the `include` query param. We now support this everywhere BigCommerce does in the checkout API.

```python
# before
add_consignment(checkout_id, include_available_shipping_options=True) 
   
# after
add_consignment(checkout_id, include=['consignments.available_shipping_options']) 
```

`include_available_shipping_options` still works on the functions that previously supported it for backwards compatibility.
