### PR TITLE
Add timeout arguments to bigc api client

### DIFF
--- a/bigc/api.py
+++ b/bigc/api.py
@@ -1,9 +1,10 @@
 from bigc.api_client import BigCommerceAPIClient
 from bigc.resources import *
+from typing import Optional
 
 
 class BigCommerceAPI:
-    def __init__(self, store_hash: str, access_token: str, timeout=None):
+    def __init__(self, store_hash: str, access_token: str, timeout: Optional[int] = None):
         api_client = BigCommerceAPIClient(store_hash, access_token, timeout)
 
         self.carts: BigCommerceCartsAPI = BigCommerceCartsAPI(api_client)

--- a/bigc/api.py
+++ b/bigc/api.py
@@ -4,7 +4,7 @@ from typing import Optional
 
 
 class BigCommerceAPI:
-    def __init__(self, store_hash: str, access_token: str, timeout: Optional[int] = None):
+    def __init__(self, store_hash: str, access_token: str, timeout: Optional[float] = None):
         api_client = BigCommerceAPIClient(store_hash, access_token, timeout)
 
         self.carts: BigCommerceCartsAPI = BigCommerceCartsAPI(api_client)

--- a/bigc/api.py
+++ b/bigc/api.py
@@ -3,8 +3,8 @@ from bigc.resources import *
 
 
 class BigCommerceAPI:
-    def __init__(self, store_hash: str, access_token: str):
-        api_client = BigCommerceAPIClient(store_hash, access_token)
+    def __init__(self, store_hash: str, access_token: str, timeout=None):
+        api_client = BigCommerceAPIClient(store_hash, access_token, timeout)
 
         self.carts: BigCommerceCartsAPI = BigCommerceCartsAPI(api_client)
         self.categories: BigCommerceCategoriesAPI = BigCommerceCategoriesAPI(api_client)

--- a/bigc/api_client.py
+++ b/bigc/api_client.py
@@ -13,7 +13,7 @@ MAX_V3_PAGE_SIZE = 250
 
 
 class BigCommerceRequestClient(ABC):
-    def __init__(self, store_hash: str, access_token: str, timeout=None):
+    def __init__(self, store_hash: str, access_token: str, timeout: Optional[float] = None):
         self.store_hash = store_hash
         self.access_token = access_token
         self.timeout = timeout

--- a/bigc/api_client.py
+++ b/bigc/api_client.py
@@ -13,13 +13,15 @@ MAX_V3_PAGE_SIZE = 250
 
 
 class BigCommerceRequestClient(ABC):
-    def __init__(self, store_hash: str, access_token: str):
+    def __init__(self, store_hash: str, access_token: str, timeout=None):
         self.store_hash = store_hash
         self.access_token = access_token
+        self.timeout = timeout
 
     def request(self, method: str, path: str, **kwargs):
         """Make a request to the BigCommerce API (uses Requests internally)"""
         kwargs['headers'] = self._get_standard_request_headers() | kwargs.get('headers', {})
+        kwargs.setdefault('timeout', self.timeout)
 
         try:
             response = requests.request(method, self._prepare_url(path), **kwargs)


### PR DESCRIPTION
Add timeout with default as `None` to requests. 

Closes [SHIP-116](https://linear.app/medshift/issue/SHIP-116/timeouts-on-bigcommerce-api-calls)