### PR TITLE
Add Retry Logic

### DIFF
--- a/bigc/api.py
+++ b/bigc/api.py
@@ -5,9 +5,9 @@ from bigc.resources import *
 
 
 class BigCommerceAPI:
-    def __init__(self, store_hash: str, access_token: str, timeout: Optional[float] = None):
-        self.api_v2 = api_v2 = BigCommerceV2APIClient(store_hash, access_token, timeout)
-        self.api_v3 = api_v3 = BigCommerceV3APIClient(store_hash, access_token, timeout)
+    def __init__(self, store_hash: str, access_token: str, *, timeout: float | None = None, get_retries: int | None = None):
+        self.api_v2 = api_v2 = BigCommerceV2APIClient(store_hash, access_token, timeout=timeout, get_retries=get_retries)
+        self.api_v3 = api_v3 = BigCommerceV3APIClient(store_hash, access_token, timeout=timeout, get_retries=get_retries)
 
         self.carts_v3: BigCommerceCartsV3API = BigCommerceCartsV3API(api_v3)
         self.checkouts_v3: BigCommerceCheckoutsV3API = BigCommerceCheckoutsV3API(api_v3)

--- a/bigc/api_client.py
+++ b/bigc/api_client.py
@@ -18,7 +18,7 @@ MAX_V3_PAGE_SIZE = 250
 
 
 class BigCommerceRequestClient(ABC):
-    def __init__(self, store_hash: str, access_token: str, timeout: float | None = None, retries: int | None = None):
+    def __init__(self, store_hash: str, access_token: str, *, timeout: float | None = None, retries: int | None = None):
         self.store_hash = store_hash
         self.access_token = access_token
         self.timeout = timeout

--- a/bigc/api_client.py
+++ b/bigc/api_client.py
@@ -42,7 +42,10 @@ class BigCommerceRequestClient(ABC):
         if timeout is None:
             timeout = self.timeout
         if retries is None and method != 'POST':
-            retries = self.retries if self.retries is not None else (2 if method == 'GET' else 0)
+            if self.retries is None:
+                retries = 2 if method == 'GET' else 0
+            else:
+                retries = self.retries
 
         self._validate_path(path)
         self._validate_retries(method, retries)

--- a/bigc/api_client.py
+++ b/bigc/api_client.py
@@ -18,11 +18,11 @@ MAX_V3_PAGE_SIZE = 250
 
 
 class BigCommerceRequestClient(ABC):
-    def __init__(self, store_hash: str, access_token: str, *, timeout: float | None = None, retries: int | None = None):
+    def __init__(self, store_hash: str, access_token: str, *, timeout: float | None = None, get_retries: int | None = None):
         self.store_hash = store_hash
         self.access_token = access_token
         self.timeout = timeout
-        self.retries = retries
+        self.get_retries = get_retries
 
     def request(
             self,
@@ -41,11 +41,11 @@ class BigCommerceRequestClient(ABC):
             headers = {}
         if timeout is None:
             timeout = self.timeout
-        if retries is None and method != 'POST':
-            if self.retries is None:
-                retries = 2 if method == 'GET' else 0
-            else:
-                retries = self.retries
+        if retries is None:
+            if method == 'GET':
+                retries = self.get_retries
+
+            retries = retries or 0
 
         self._validate_path(path)
         self._validate_retries(method, retries)

--- a/bigc/resources/carts_v3.py
+++ b/bigc/resources/carts_v3.py
@@ -16,9 +16,10 @@ class BigCommerceCartsV3API:
             *,
             params: dict[str, Any] | None = None,
             timeout: float | None = None,
+            retries: int | None = None,
     ) -> dict[str, Any]:
         """Get a specific cart by its ID"""
-        return self._api.get(f'/carts/{cart_id}', params=params, timeout=timeout)
+        return self._api.get(f'/carts/{cart_id}', params=params, timeout=timeout, retries=retries)
 
     def create(
             self,
@@ -30,13 +31,20 @@ class BigCommerceCartsV3API:
         """Create a new cart"""
         return self._api.post('/carts', data=data, params=params, timeout=timeout)
 
-    def update(self, cart_id: UUIDLike, data: dict[str, Any], *, timeout: float | None = None) -> dict[str, Any]:
+    def update(
+            self,
+            cart_id: UUIDLike,
+            data: dict[str, Any],
+            *,
+            timeout: float | None = None,
+            retries: int | None = None,
+    ) -> dict[str, Any]:
         """Update a specific cart by its ID"""
-        return self._api.put(f'/carts/{cart_id}', data=data, timeout=timeout)
+        return self._api.put(f'/carts/{cart_id}', data=data, timeout=timeout, retries=retries)
 
-    def delete(self, cart_id: UUIDLike, *, timeout: float | None = None) -> None:
+    def delete(self, cart_id: UUIDLike, *, timeout: float | None = None, retries: int | None = None) -> None:
         """Delete a specific cart by its ID"""
-        self._api.delete(f'/carts/{cart_id}', timeout=timeout)
+        self._api.delete(f'/carts/{cart_id}', timeout=timeout, retries=retries)
 
     def add_line_items(
             self,
@@ -57,9 +65,10 @@ class BigCommerceCartsV3API:
             *,
             params: dict[str, Any] | None = None,
             timeout: float | None = None,
+            retries: int | None = None,
     ) -> dict[str, Any]:
         """Update a single line item in a cart"""
-        return self._api.put(f'/carts/{cart_id}/items/{item_id}', data=data, params=params, timeout=timeout)
+        return self._api.put(f'/carts/{cart_id}/items/{item_id}', data=data, params=params, timeout=timeout, retries=retries)
 
     def delete_line_item(
             self,
@@ -68,9 +77,10 @@ class BigCommerceCartsV3API:
             *,
             params: dict[str, Any] | None = None,
             timeout: float | None = None,
+            retries: int | None = None,
     ) -> dict[str, Any]:
         """Remove a line item from a cart"""
-        return self._api.delete(f'/carts/{cart_id}/items/{item_id}', params=params, timeout=timeout)
+        return self._api.delete(f'/carts/{cart_id}/items/{item_id}', params=params, timeout=timeout, retries=retries)
 
     def create_redirect_url(
             self,

--- a/bigc/resources/categories_v3.py
+++ b/bigc/resources/categories_v3.py
@@ -12,22 +12,29 @@ class BigCommerceCategoriesV3API:
             *,
             params: dict[str, Any] | None = None,
             timeout: float | None = None,
+            retries: int | None = None,
     ) -> Iterator[dict[str, Any]]:
         """Return an iterator for all categories"""
-        return self._api.get_many('/catalog/categories', params=params, timeout=timeout)
+        return self._api.get_many('/catalog/categories', params=params, timeout=timeout, retries=retries)
 
-    def get(self, category_id: int, *, timeout: float | None = None) -> dict[str, Any]:
+    def get(self, category_id: int, *, timeout: float | None = None, retries: int | None = None) -> dict[str, Any]:
         """Get a specific category by its ID"""
-        return self._api.get(f'/catalog/categories/{category_id}', timeout=timeout)
+        return self._api.get(f'/catalog/categories/{category_id}', timeout=timeout, retries=retries)
 
     def create(self, data: dict[str, Any], timeout: float | None = None) -> dict[str, Any]:
         """Create a category"""
         return self._api.post('/catalog/categories', data=data, timeout=timeout)
 
-    def update(self, category_id: int, data: dict[str, Any], timeout: float | None = None) -> dict[str, Any]:
+    def update(
+            self,
+            category_id: int,
+            data: dict[str, Any],
+            timeout: float | None = None,
+            retries: int | None = None,
+    ) -> dict[str, Any]:
         """Update a specific category by its ID"""
-        return self._api.put(f'/catalog/categories/{category_id}', data=data, timeout=timeout)
+        return self._api.put(f'/catalog/categories/{category_id}', data=data, timeout=timeout, retries=retries)
 
-    def delete(self, category_id: int, *, timeout: float | None = None) -> dict[str, Any]:
+    def delete(self, category_id: int, *, timeout: float | None = None, retries: int | None = None) -> dict[str, Any]:
         """Delete a specific category by its ID"""
-        return self._api.delete(f'/catalog/categories/{category_id}', timeout=timeout)
+        return self._api.delete(f'/catalog/categories/{category_id}', timeout=timeout, retries=retries)

--- a/bigc/resources/checkouts_v3.py
+++ b/bigc/resources/checkouts_v3.py
@@ -16,13 +16,21 @@ class BigCommerceCheckoutsV3API:
             *,
             params: dict[str, Any] | None = None,
             timeout: float | None = None,
+            retries: int | None = None,
     ) -> dict[str, Any]:
         """Get a specific checkout by its ID"""
-        return self._api.get(f'/checkouts/{checkout_id}', params=params, timeout=timeout)
+        return self._api.get(f'/checkouts/{checkout_id}', params=params, timeout=timeout, retries=retries)
 
-    def update(self, checkout_id: UUIDLike, data: dict[str, Any], *, timeout: float | None = None) -> dict[str, Any]:
+    def update(
+            self,
+            checkout_id: UUIDLike,
+            data: dict[str, Any],
+            *,
+            timeout: float | None = None,
+            retries: int | None = None,
+    ) -> dict[str, Any]:
         """Change customer message pertaining to an existing Checkout"""
-        return self._api.put(f'/checkouts/{checkout_id}', data=data, timeout=timeout)
+        return self._api.put(f'/checkouts/{checkout_id}', data=data, timeout=timeout, retries=retries)
 
     def add_billing_address(
             self,
@@ -39,16 +47,20 @@ class BigCommerceCheckoutsV3API:
             checkout_id: UUIDLike,
             address_id: str,
             data: dict[str, Any],
+            *,
             timeout: float | None = None,
+            retries: int | None = None,
     ) -> dict[str, Any]:
         """Update an existing billing address on a checkout"""
-        return self._api.put(f'/checkouts/{checkout_id}/billing-address/{address_id}', data=data, timeout=timeout)
+        return self._api.put(f'/checkouts/{checkout_id}/billing-address/{address_id}', data=data, timeout=timeout, retries=retries)
 
     def add_consignment(
             self,
             checkout_id: UUIDLike,
             data: dict[str, Any],
-            params: dict[str, Any] | None = None, timeout: float | None = None,
+            *,
+            params: dict[str, Any] | None = None,
+            timeout: float | None = None,
     ) -> dict[str, Any]:
         """Add a new consignment to a checkout"""
         return self._api.post(f'/checkouts/{checkout_id}/consignments', data=data, params=params, timeout=timeout)
@@ -58,10 +70,13 @@ class BigCommerceCheckoutsV3API:
             checkout_id: UUIDLike,
             consignment_id: str,
             data: dict[str, Any],
-            params: dict[str, Any] | None = None, timeout: float | None = None,
+            *,
+            params: dict[str, Any] | None = None,
+            timeout: float | None = None,
+            retries: int | None = None,
     ) -> dict[str, Any]:
         """Update an existing consignment's selected shipping option"""
-        return self._api.put(f'/checkouts/{checkout_id}/consignments/{consignment_id}', data=data, params=params, timeout=timeout)
+        return self._api.put(f'/checkouts/{checkout_id}/consignments/{consignment_id}', data=data, params=params, timeout=timeout, retries=retries)
 
     def delete_consignment(
             self,
@@ -70,9 +85,10 @@ class BigCommerceCheckoutsV3API:
             *,
             params: dict[str, Any] | None = None,
             timeout: float | None = None,
+            retries: int | None = None,
     ) -> dict[str, Any]:
         """Remove an existing consignment from a checkout"""
-        return self._api.delete(f'/checkouts/{checkout_id}/consignments/{consignment_id}', params=params, timeout=timeout)
+        return self._api.delete(f'/checkouts/{checkout_id}/consignments/{consignment_id}', params=params, timeout=timeout, retries=retries)
 
     def add_coupon(
             self,
@@ -92,9 +108,10 @@ class BigCommerceCheckoutsV3API:
             *,
             params: dict[str, Any] | None = None,
             timeout: float | None = None,
+            retries: int | None = None,
     ) -> dict[str, Any]:
         """Delete a coupon code from a checkout"""
-        return self._api.delete(f'/checkouts/{checkout_id}/coupons/{coupon_code}', params=params, timeout=timeout)
+        return self._api.delete(f'/checkouts/{checkout_id}/coupons/{coupon_code}', params=params, timeout=timeout, retries=retries)
 
     def add_discounts(
             self,

--- a/bigc/resources/currencies_v2.py
+++ b/bigc/resources/currencies_v2.py
@@ -7,10 +7,23 @@ class BigCommerceCurrenciesV2API:
     def __init__(self, api: BigCommerceV2APIClient):
         self._api = api
 
-    def all(self, *, params: dict[str, Any] | None = None, timeout: float | None = None) -> Iterator[dict[str, Any]]:
+    def all(
+            self,
+            *,
+            params: dict[str, Any] | None = None,
+            timeout: float | None = None,
+            retries: int | None = None,
+    ) -> Iterator[dict[str, Any]]:
         """Return an iterator for all currencies"""
-        return self._api.get_many('/currencies', params=params, timeout=timeout)
+        return self._api.get_many('/currencies', params=params, timeout=timeout, retries=retries)
 
-    def get(self, currency_id: int, *, params: dict[str, Any] | None = None, timeout: float | None = None):
+    def get(
+            self,
+            currency_id: int,
+            *,
+            params: dict[str, Any] | None = None,
+            timeout: float | None = None,
+            retries: int | None = None,
+    ):
         """Get a specific currency by its ID"""
-        return self._api.get(f'/currencies/{currency_id}', params=params, timeout=timeout)
+        return self._api.get(f'/currencies/{currency_id}', params=params, timeout=timeout, retries=retries)

--- a/bigc/resources/customer_groups_v2.py
+++ b/bigc/resources/customer_groups_v2.py
@@ -7,9 +7,15 @@ class BigCommerceCustomerGroupsV2API:
     def __init__(self, api: BigCommerceV2APIClient):
         self._api = api
 
-    def all(self, *, params: dict[str, Any] | None = None, timeout: float | None = None) -> Iterator[dict[str, Any]]:
+    def all(
+            self,
+            *,
+            params: dict[str, Any] | None = None,
+            timeout: float | None = None,
+            retries: int | None = None,
+    ) -> Iterator[dict[str, Any]]:
         """Return an iterator for all customer groups"""
-        return self._api.get_many('/customer_groups', params=params, timeout=timeout)
+        return self._api.get_many('/customer_groups', params=params, timeout=timeout, retries=retries)
 
     def get(
             self,
@@ -17,18 +23,32 @@ class BigCommerceCustomerGroupsV2API:
             *,
             params: dict[str, Any] | None = None,
             timeout: float | None = None,
+            retries: int | None = None,
     ) -> dict[str, Any]:
         """Get a specific customer group by its ID"""
-        return self._api.get(f'/customer_groups/{customer_group_id}', params=params, timeout=timeout)
+        return self._api.get(f'/customer_groups/{customer_group_id}', params=params, timeout=timeout, retries=retries)
 
     def create(self, data: dict[str, Any], *, timeout: float | None = None) -> dict[str, Any]:
         """Create a customer group"""
         return self._api.post('/customer_groups', data=data, timeout=timeout)
 
-    def update(self, customer_group_id: int, data: dict[str, Any], *, timeout: float | None = None) -> dict[str, Any]:
+    def update(
+            self,
+            customer_group_id: int,
+            data: dict[str, Any],
+            *,
+            timeout: float | None = None,
+            retries: int | None = None,
+    ) -> dict[str, Any]:
         """Update a specific customer group by its ID"""
-        return self._api.put(f'/customer_groups/{customer_group_id}', data=data, timeout=timeout)
+        return self._api.put(f'/customer_groups/{customer_group_id}', data=data, timeout=timeout, retries=retries)
 
-    def delete(self, customer_group_id: int, *, timeout: float | None = None) -> dict[str, Any]:
+    def delete(
+            self,
+            customer_group_id: int,
+            *,
+            timeout: float | None = None,
+            retries: int | None = None,
+    ) -> dict[str, Any]:
         """Delete a specific customer group by its ID"""
-        return self._api.delete(f'/customer_groups/{customer_group_id}', timeout=timeout)
+        return self._api.delete(f'/customer_groups/{customer_group_id}', timeout=timeout, retries=retries)

--- a/bigc/resources/customers_v3.py
+++ b/bigc/resources/customers_v3.py
@@ -8,9 +8,15 @@ class BigCommerceCustomersV3API:
     def __init__(self, api: BigCommerceV3APIClient):
         self._api = api
 
-    def all(self, *, params: dict[str, Any] | None = None, timeout: float | None = None) -> Iterator[dict[str, Any]]:
+    def all(
+            self,
+            *,
+            params: dict[str, Any] | None = None,
+            timeout: float | None = None,
+            retries: int | None = None,
+    ) -> Iterator[dict[str, Any]]:
         """Return an iterator for all customers"""
-        return self._api.get_many('/customers', params=params, timeout=timeout, cursor=True)
+        return self._api.get_many('/customers', params=params, timeout=timeout, retries=retries, cursor=True)
 
     def get(
             self,
@@ -18,6 +24,7 @@ class BigCommerceCustomersV3API:
             *,
             params: dict[str, Any] | None = None,
             timeout: float | None = None,
+            retries: int | None = None,
     ) -> dict[str, Any]:
         """Get a specific customer by its ID"""
         params = {
@@ -26,7 +33,7 @@ class BigCommerceCustomersV3API:
         }
 
         try:
-            return self._api.get('/customers', params=params, timeout=timeout)[0]
+            return self._api.get('/customers', params=params, timeout=timeout, retries=retries)[0]
         except IndexError:
             raise DoesNotExistError() from None
 
@@ -38,32 +45,64 @@ class BigCommerceCustomersV3API:
         """Create a single customer"""
         return self.create_many([data], timeout=timeout)[0]
 
-    def update_many(self, data: list[dict[str, Any]], *, timeout: float | None = None) -> list[dict[str, Any]]:
+    def update_many(
+            self,
+            data: list[dict[str, Any]],
+            *,
+            timeout: float | None = None,
+            retries: int | None = None,
+    ) -> list[dict[str, Any]]:
         """Update many customers"""
-        return self._api.put('/customers', data=data, timeout=timeout)
+        return self._api.put('/customers', data=data, timeout=timeout, retries=retries)
 
-    def update(self, customer_id: int, data: dict[str, Any], *, timeout: float | None = None) -> dict[str, Any]:
+    def update(
+            self,
+            customer_id: int,
+            data: dict[str, Any],
+            *,
+            timeout: float | None = None,
+            retries: int | None = None,
+    ) -> dict[str, Any]:
         """Update a single customer"""
         data['id'] = customer_id
 
-        return self.update_many([data], timeout=timeout)[0]
+        return self.update_many([data], timeout=timeout, retries=retries)[0]
 
-    def delete_many(self, *, params: dict[str, Any] | None = None, timeout: float | None = None) -> None:
+    def delete_many(
+            self,
+            *,
+            params: dict[str, Any] | None = None,
+            timeout: float | None = None,
+            retries: int | None = None,
+    ) -> None:
         """Delete many customers"""
-        self._api.delete(f'/customers', params=params, timeout=timeout)
+        self._api.delete(f'/customers', params=params, timeout=timeout, retries=retries)
 
-    def delete(self, customer_id: int, *, params: dict[str, Any] | None = None, timeout: float | None = None) -> None:
+    def delete(
+            self,
+            customer_id: int,
+            *,
+            params: dict[str, Any] | None = None,
+            timeout: float | None = None,
+            retries: int | None = None,
+    ) -> None:
         """Delete a single customer"""
         params = {
             **(params or {}),
             'id:in': customer_id,
         }
 
-        self.delete_many(params=params, timeout=timeout)
+        self.delete_many(params=params, timeout=timeout, retries=retries)
 
-    def update_form_fields(self, data: list[dict[str, Any]], *, timeout: float | None = None) -> list[dict[str, Any]]:
+    def update_form_fields(
+            self,
+            data: list[dict[str, Any]],
+            *,
+            timeout: float | None = None,
+            retries: int | None = None,
+    ) -> list[dict[str, Any]]:
         """Update form-field values"""
-        return self._api.put('/customers/form-field-values', data=data, timeout=timeout)
+        return self._api.put('/customers/form-field-values', data=data, timeout=timeout, retries=retries)
 
     def update_form_field(
             self,
@@ -71,18 +110,20 @@ class BigCommerceCustomersV3API:
             data: dict[str, Any],
             *,
             timeout: float | None = None,
+            retries: int | None = None,
     ) -> dict[str, Any]:
         """Update a single form-field value"""
-        return self.update_form_fields([{'customer_id': customer_id, **data}], timeout=timeout)[0]
+        return self.update_form_fields([{'customer_id': customer_id, **data}], timeout=timeout, retries=retries)[0]
 
     def all_addresses(
             self,
             *,
             params: dict[str, Any] | None = None,
             timeout: float | None = None,
+            retries: int | None = None,
     ) -> Iterator[dict[str, Any]]:
         """Get all addresses, optionally filtered by a customer's address book"""
-        return self._api.get_many(f'/customers/addresses', params=params, timeout=timeout)
+        return self._api.get_many(f'/customers/addresses', params=params, timeout=timeout, retries=retries)
 
     def get_address(
             self,
@@ -91,6 +132,7 @@ class BigCommerceCustomersV3API:
             *,
             params: dict[str, Any] | None = None,
             timeout: float | None = None,
+            retries: int | None = None,
     ) -> dict[str, Any]:
         """Get one address by its ID, from a customer's address book"""
         params = {
@@ -100,7 +142,7 @@ class BigCommerceCustomersV3API:
         }
 
         try:
-            return self._api.get(f'/customers/addresses', params=params, timeout=timeout)[0]
+            return self._api.get(f'/customers/addresses', params=params, timeout=timeout, retries=retries)[0]
         except IndexError:
             raise DoesNotExistError() from None
 
@@ -115,20 +157,39 @@ class BigCommerceCustomersV3API:
         except IndexError:
             raise InvalidDataError('This address already exists.') from None
 
-    def update_addresses(self, data: list[dict[str, Any]], *, timeout: float | None = None) -> list[dict[str, Any]]:
+    def update_addresses(
+            self,
+            data: list[dict[str, Any]],
+            *,
+            timeout: float | None = None,
+            retries: int | None = None,
+    ) -> list[dict[str, Any]]:
         """Update many addresses"""
-        return self._api.put('/customers/addresses', data=data, timeout=timeout)
+        return self._api.put('/customers/addresses', data=data, timeout=timeout, retries=retries)
 
-    def update_address(self, address_id: int, data: dict[str, Any], *, timeout: float | None = None) -> dict[str, Any]:
+    def update_address(
+            self,
+            address_id: int,
+            data: dict[str, Any],
+            *,
+            timeout: float | None = None,
+            retries: int | None = None,
+    ) -> dict[str, Any]:
         """Update an address by its ID"""
         try:
-            return self.update_addresses([{'id': address_id, **data}], timeout=timeout)[0]
+            return self.update_addresses([{'id': address_id, **data}], timeout=timeout, retries=retries)[0]
         except IndexError:
             raise InvalidDataError('This address already exists.') from None
 
-    def delete_addresses(self, *, params: dict[str, Any] | None = None, timeout: float | None = None) -> None:
+    def delete_addresses(
+            self,
+            *,
+            params: dict[str, Any] | None = None,
+            timeout: float | None = None,
+            retries: int | None = None,
+    ) -> None:
         """Delete many addresses"""
-        self._api.delete(f"/customers/addresses", params=params, timeout=timeout)
+        self._api.delete(f"/customers/addresses", params=params, timeout=timeout, retries=retries)
 
     def delete_address(
             self,
@@ -136,6 +197,7 @@ class BigCommerceCustomersV3API:
             *,
             params: dict[str, Any] | None = None,
             timeout: float | None = None,
+            retries: int | None = None,
     ) -> None:
         """Delete an address by its ID"""
         params = {
@@ -143,4 +205,4 @@ class BigCommerceCustomersV3API:
             'id:in': address_id,
         }
 
-        self.delete_addresses(params=params, timeout=timeout)
+        self.delete_addresses(params=params, timeout=timeout, retries=retries)

--- a/bigc/resources/orders_v2.py
+++ b/bigc/resources/orders_v2.py
@@ -7,9 +7,15 @@ class BigCommerceOrdersV2API:
     def __init__(self, api: BigCommerceV2APIClient):
         self._api = api
 
-    def all(self, *, params: dict[str, Any] | None = None, timeout: float | None = None) -> Iterator[dict[str, Any]]:
+    def all(
+            self,
+            *,
+            params: dict[str, Any] | None = None,
+            timeout: float | None = None,
+            retries: int | None = None,
+    ) -> Iterator[dict[str, Any]]:
         """Return an iterator for all orders"""
-        return self._api.get_many('/orders', params=params, timeout=timeout)
+        return self._api.get_many('/orders', params=params, timeout=timeout, retries=retries)
 
     def get(
             self,
@@ -17,9 +23,10 @@ class BigCommerceOrdersV2API:
             *,
             params: dict[str, Any] | None = None,
             timeout: float | None = None,
+            retries: int | None = None,
     ) -> dict[str, Any]:
         """Get an order by its ID"""
-        return self._api.get(f'/orders/{order_id}', params=params, timeout=timeout)
+        return self._api.get(f'/orders/{order_id}', params=params, timeout=timeout, retries=retries)
 
     def create(
             self,
@@ -31,13 +38,26 @@ class BigCommerceOrdersV2API:
         """Create an order"""
         return self._api.post('/orders', data=data, params=params, timeout=timeout)
 
-    def update(self, order_id: int, data: dict[str, Any], *, timeout: float | None = None) -> dict[str, Any]:
+    def update(
+            self,
+            order_id: int,
+            data: dict[str, Any],
+            *,
+            timeout: float | None = None,
+            retries: int | None = None,
+    ) -> dict[str, Any]:
         """Update a specific order by its ID"""
-        return self._api.put(f'/orders/{order_id}', data=data, timeout=timeout)
+        return self._api.put(f'/orders/{order_id}', data=data, timeout=timeout, retries=retries)
 
-    def archive(self, order_id: int, *, timeout: float | None = None) -> None:
+    def archive(
+            self,
+            order_id: int,
+            *,
+            timeout: float | None = None,
+            retries: int | None = None,
+    ) -> None:
         """Archive a specific order by its ID"""
-        self._api.delete(f'/orders/{order_id}', timeout=timeout)
+        self._api.delete(f'/orders/{order_id}', timeout=timeout, retries=retries)
 
     def all_products(
             self,
@@ -45,13 +65,21 @@ class BigCommerceOrdersV2API:
             *,
             params: dict[str, Any] | None = None,
             timeout: float | None = None,
+            retries: int | None = None,
     ) -> Iterator[dict[str, Any]]:
         """Return an iterator for all order products in an order"""
-        return self._api.get_many(f'/orders/{order_id}/products', params=params, timeout=timeout)
+        return self._api.get_many(f'/orders/{order_id}/products', params=params, timeout=timeout, retries=retries)
 
-    def get_product(self, order_id: int, product_id: int, *, timeout: float | None = None) -> dict[str, Any]:
+    def get_product(
+            self,
+            order_id: int,
+            product_id: int,
+            *,
+            timeout: float | None = None,
+            retries: int | None = None,
+    ) -> dict[str, Any]:
         """Get a specific order product in an order by ID"""
-        return self._api.get(f'/orders/{order_id}/products/{product_id}', timeout=timeout)
+        return self._api.get(f'/orders/{order_id}/products/{product_id}', timeout=timeout, retries=retries)
 
     def all_shipping_addresses(
             self,
@@ -59,13 +87,21 @@ class BigCommerceOrdersV2API:
             *,
             params: dict[str, Any] | None = None,
             timeout: float | None = None,
+            retries: int | None = None,
     ) -> Iterator[dict[str, Any]]:
         """Return an iterator for all order shipping addresses in an order"""
-        return self._api.get_many(f'/orders/{order_id}/shipping_addresses', params=params, timeout=timeout)
+        return self._api.get_many(f'/orders/{order_id}/shipping_addresses', params=params, timeout=timeout, retries=retries)
 
-    def get_shipping_address(self, order_id: int, address_id: int, *, timeout: float | None = None) -> dict[str, Any]:
+    def get_shipping_address(
+            self,
+            order_id: int,
+            address_id: int,
+            *,
+            timeout: float | None = None,
+            retries: int | None = None,
+    ) -> dict[str, Any]:
         """Get a specific shipping address in an order by ID"""
-        return self._api.get(f'/orders/{order_id}/shipping_addresses/{address_id}', timeout=timeout)
+        return self._api.get(f'/orders/{order_id}/shipping_addresses/{address_id}', timeout=timeout, retries=retries)
 
     def update_shipping_address(
             self,
@@ -74,9 +110,10 @@ class BigCommerceOrdersV2API:
             data: dict[str, Any],
             *,
             timeout: float | None = None,
+            retries: int | None = None,
     ) -> dict[str, Any]:
         """Update a specific shipping address in an order by ID"""
-        return self._api.put(f'/orders/{order_id}/shipping_addresses/{address_id}', data=data, timeout=timeout)
+        return self._api.put(f'/orders/{order_id}/shipping_addresses/{address_id}', data=data, timeout=timeout, retries=retries)
 
     def all_shipments(
             self,
@@ -84,13 +121,21 @@ class BigCommerceOrdersV2API:
             *,
             params: dict[str, Any] | None = None,
             timeout: float | None = None,
+            retries: int | None = None,
     ) -> Iterator[dict[str, Any]]:
         """Returns all shipments for a specified order"""
-        return self._api.get_many(f'/orders/{order_id}/shipments', params=params, timeout=timeout)
+        return self._api.get_many(f'/orders/{order_id}/shipments', params=params, timeout=timeout, retries=retries)
 
-    def get_shipment(self, order_id: int, shipment_id: int, *, timeout: float | None = None) -> dict[str, Any]:
+    def get_shipment(
+            self,
+            order_id: int,
+            shipment_id: int,
+            *,
+            timeout: float | None = None,
+            retries: int | None = None,
+    ) -> dict[str, Any]:
         """Get a shipment by its ID"""
-        return self._api.get(f'/orders/{order_id}/shipments/{shipment_id}', timeout=timeout)
+        return self._api.get(f'/orders/{order_id}/shipments/{shipment_id}', timeout=timeout, retries=retries)
 
     def create_shipment(self, order_id: int, data: dict[str, Any], *, timeout: float | None = None) -> dict[str, Any]:
         """Creates an order shipment for the specified order"""
@@ -103,13 +148,21 @@ class BigCommerceOrdersV2API:
             data: dict[str, Any],
             *,
             timeout: float | None = None,
+            retries: int | None = None,
     ) -> dict[str, Any]:
         """Updates an order shipment for the specified order"""
-        return self._api.put(f'/orders/{order_id}/shipments/{shipment_id}', data=data, timeout=timeout)
+        return self._api.put(f'/orders/{order_id}/shipments/{shipment_id}', data=data, timeout=timeout, retries=retries)
 
-    def delete_shipment(self, order_id: int, shipment_id: int, *, timeout: float | None = None) -> None:
+    def delete_shipment(
+            self,
+            order_id: int,
+            shipment_id: int,
+            *,
+            timeout: float | None = None,
+            retries: int | None = None,
+    ) -> None:
         """Deletes specific shipment by its ID"""
-        return self._api.delete(f'/orders/{order_id}/shipments/{shipment_id}', timeout=timeout)
+        return self._api.delete(f'/orders/{order_id}/shipments/{shipment_id}', timeout=timeout, retries=retries)
 
     def all_coupons(
             self,
@@ -117,6 +170,7 @@ class BigCommerceOrdersV2API:
             *,
             params: dict[str, Any] | None = None,
             timeout: float | None = None,
+            retries: int | None = None,
     ) -> Iterator[dict[str, Any]]:
         """Return an iterator for all coupons in an order"""
-        return self._api.get_many(f'/orders/{order_id}/coupons', params=params, timeout=timeout)
+        return self._api.get_many(f'/orders/{order_id}/coupons', params=params, timeout=timeout, retries=retries)

--- a/bigc/resources/orders_v3.py
+++ b/bigc/resources/orders_v3.py
@@ -8,9 +8,16 @@ class BigCommerceOrdersV3API:
     def __init__(self, api: BigCommerceV3APIClient):
         self._api = api
 
-    def get_refund_quote(self, order_id: int, data: dict[str, Any], *, timeout: float | None = None) -> dict[str, Any]:
+    def get_refund_quote(
+            self,
+            order_id: int,
+            data: dict[str, Any],
+            *,
+            timeout: float | None = None,
+            retries: int | None = None,
+    ) -> dict[str, Any]:
         """Get a refund quote for an order by ID"""
-        return self._api.post(f'/orders/{order_id}/payment_actions/refund_quotes', data=data, timeout=timeout)
+        return self._api.post(f'/orders/{order_id}/payment_actions/refund_quotes', data=data, timeout=timeout, retries=retries)
 
     def create_refund(
             self,
@@ -29,6 +36,7 @@ class BigCommerceOrdersV3API:
             *,
             params: dict[str, Any] | None = None,
             timeout: float | None = None,
+            retries: int | None = None,
     ) -> Iterator[dict[str, Any]]:
         """Return an iterator for all refunds, optionally filtered by order"""
         if order_id:
@@ -36,7 +44,7 @@ class BigCommerceOrdersV3API:
         else:
             endpoint = '/orders/payment_actions/refunds'
 
-        return self._api.get_many(endpoint, params=params, timeout=timeout)
+        return self._api.get_many(endpoint, params=params, timeout=timeout, retries=retries)
 
     def get_refund(
             self,
@@ -44,6 +52,7 @@ class BigCommerceOrdersV3API:
             *,
             params: dict[str, Any] | None = None,
             timeout: float | None = None,
+            retries: int | None = None,
     ) -> dict[str, Any]:
         """Get a specific refund by its ID"""
         params = {
@@ -52,6 +61,6 @@ class BigCommerceOrdersV3API:
         }
 
         try:
-            return self._api.get('/orders/payment_actions/refunds', params=params, timeout=timeout)[0]
+            return self._api.get('/orders/payment_actions/refunds', params=params, timeout=timeout, retries=retries)[0]
         except IndexError:
             raise DoesNotExistError() from None

--- a/bigc/resources/pricing_v3.py
+++ b/bigc/resources/pricing_v3.py
@@ -7,6 +7,12 @@ class BigCommercePricingV3API:
     def __init__(self, api: BigCommerceV3APIClient):
         self._api = api
 
-    def get_pricing(self, data: dict[str, Any], *, timeout: float | None = None) -> Iterator[dict[str, Any]]:
+    def get_pricing(
+            self,
+            data: dict[str, Any],
+            *,
+            timeout: float | None = None,
+            retries: int | None = None,
+    ) -> Iterator[dict[str, Any]]:
         """Return an iterator for batch product pricing"""
-        return self._api.post('/pricing/products', data=data, timeout=timeout)
+        return self._api.post('/pricing/products', data=data, timeout=timeout, retries=retries)

--- a/bigc/resources/product_variants_v3.py
+++ b/bigc/resources/product_variants_v3.py
@@ -13,9 +13,10 @@ class BigCommerceProductVariantsV3API:
             *,
             params: dict[str, Any] | None = None,
             timeout: float | None = None,
+            retries: int | None = None,
     ) -> Iterator[dict[str, Any]]:
         """Return an iterator for all variants of a product"""
-        return self._api.get_many(f'/catalog/products/{product_id}/variants', params=params, timeout=timeout)
+        return self._api.get_many(f'/catalog/products/{product_id}/variants', params=params, timeout=timeout, retries=retries)
 
     def get(
             self,
@@ -24,9 +25,10 @@ class BigCommerceProductVariantsV3API:
             *,
             params: dict[str, Any] | None = None,
             timeout: float | None = None,
+            retries: int | None = None,
     ) -> dict[str, Any]:
         """Get a specific product variant by ID"""
-        return self._api.get(f'/catalog/products/{product_id}/variants/{variant_id}', params=params, timeout=timeout)
+        return self._api.get(f'/catalog/products/{product_id}/variants/{variant_id}', params=params, timeout=timeout, retries=retries)
 
     def create(
             self,
@@ -45,9 +47,10 @@ class BigCommerceProductVariantsV3API:
             data: dict[str, Any],
             *,
             timeout: float | None = None,
+            retries: int | None = None,
     ) -> dict[str, Any]:
         """Update a specific product variant by its ID"""
-        return self._api.put(f'/catalog/products/{product_id}/variants/{variant_id}', data=data, timeout=timeout)
+        return self._api.put(f'/catalog/products/{product_id}/variants/{variant_id}', data=data, timeout=timeout, retries=retries)
 
     def delete(
             self,
@@ -55,6 +58,7 @@ class BigCommerceProductVariantsV3API:
             variant_id: int,
             *,
             timeout: float | None = None,
+            retries: int | None = None,
     ) -> dict[str, Any]:
         """Delete a specific product variant by its ID"""
-        return self._api.delete(f'/catalog/products/{product_id}/variants/{variant_id}', timeout=timeout)
+        return self._api.delete(f'/catalog/products/{product_id}/variants/{variant_id}', timeout=timeout, retries=retries)

--- a/bigc/resources/products_v3.py
+++ b/bigc/resources/products_v3.py
@@ -12,9 +12,10 @@ class BigCommerceProductsV3API:
             *,
             params: dict[str, Any] | None = None,
             timeout: float | None = None,
+            retries: int | None = None,
     ) -> Iterator[dict[str, Any]]:
         """Return an iterator for all products"""
-        return self._api.get_many('/catalog/products', params=params, timeout=timeout)
+        return self._api.get_many('/catalog/products', params=params, timeout=timeout, retries=retries)
 
     def get(
             self,
@@ -22,9 +23,10 @@ class BigCommerceProductsV3API:
             *,
             params: dict[str, Any] | None = None,
             timeout: float | None = None,
+            retries: int | None = None,
     ) -> dict[str, Any]:
         """Get a specific product by its ID"""
-        return self._api.get(f'/catalog/products/{product_id}', params=params, timeout=timeout)
+        return self._api.get(f'/catalog/products/{product_id}', params=params, timeout=timeout, retries=retries)
 
     def create(
             self,
@@ -43,10 +45,11 @@ class BigCommerceProductsV3API:
             *,
             params: dict[str, Any] | None = None,
             timeout: float | None = None,
+            retries: int | None = None,
     ) -> dict[str, Any]:
         """Update a specific product by its ID"""
-        return self._api.put(f'/catalog/products/{product_id}', data=data, params=params, timeout=timeout)
+        return self._api.put(f'/catalog/products/{product_id}', data=data, params=params, timeout=timeout, retries=retries)
 
-    def delete(self, product_id: int, *, timeout: float | None = None) -> dict[str, Any]:
+    def delete(self, product_id: int, *, timeout: float | None = None, retries: int | None = None) -> dict[str, Any]:
         """Delete a specific product by its ID"""
-        return self._api.delete(f'/catalog/products/{product_id}', timeout=timeout)
+        return self._api.delete(f'/catalog/products/{product_id}', timeout=timeout, retries=retries)

--- a/bigc/resources/webhooks_v3.py
+++ b/bigc/resources/webhooks_v3.py
@@ -12,13 +12,14 @@ class BigCommerceWebhooksV3API:
             *,
             params: dict[str, Any] | None = None,
             timeout: float | None = None,
+            retries: int | None = None,
     ) -> Iterator[dict[str, Any]]:
         """Return an iterator for all webhooks"""
-        return self._api.get_many('/hooks', params=params, timeout=timeout)
+        return self._api.get_many('/hooks', params=params, timeout=timeout, retries=retries)
 
-    def get(self, webhook_id: int, *, timeout: float | None = None) -> dict[str, Any]:
+    def get(self, webhook_id: int, *, timeout: float | None = None, retries: int | None = None) -> dict[str, Any]:
         """Get a specific webhook by its ID"""
-        return self._api.get(f'/hooks/{webhook_id}', timeout=timeout)
+        return self._api.get(f'/hooks/{webhook_id}', timeout=timeout, retries=retries)
 
     def create(
             self,
@@ -37,10 +38,11 @@ class BigCommerceWebhooksV3API:
             *,
             params: dict[str, Any] | None = None,
             timeout: float | None = None,
+            retries: int | None = None,
     ) -> dict[str, Any]:
         """Update a specific webhook by its ID"""
-        return self._api.put(f'/hooks/{webhook_id}', data=data, params=params, timeout=timeout)
+        return self._api.put(f'/hooks/{webhook_id}', data=data, params=params, timeout=timeout, retries=retries)
 
-    def delete(self, webhook_id: int, *, timeout: float | None = None) -> dict[str, Any]:
+    def delete(self, webhook_id: int, *, timeout: float | None = None, retries: int | None = None) -> dict[str, Any]:
         """Delete a specific webhook by its ID"""
-        return self._api.delete(f'/hooks/{webhook_id}', timeout=timeout)
+        return self._api.delete(f'/hooks/{webhook_id}', timeout=timeout, retries=retries)

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -1,0 +1,59 @@
+from typing import Any, Iterator
+from unittest.mock import MagicMock
+
+import pytest
+import requests
+
+from bigc.api_client import BigCommerceRequestClient
+from bigc.exceptions import BigCommerceNetworkError
+
+
+class DummyBigCommerceRequestClient(BigCommerceRequestClient):
+    def get_many(
+        self,
+        path: str,
+        *,
+        page_size: int | None = None,
+        params: dict[str, Any] | None = None,
+        timeout: float | None = None,
+    ) -> Iterator[Any]:
+        raise NotImplementedError
+
+    def _prepare_url(self, path: str) -> str:
+        return f'https://api.example.com/stores/{self.store_hash}/test/{path.lstrip("/")}'
+
+
+@pytest.fixture
+def dummy_request_client() -> DummyBigCommerceRequestClient:
+    return DummyBigCommerceRequestClient('store_hash', 'access_token')
+
+
+@pytest.fixture
+def request_mock(monkeypatch):
+    mock_response = MagicMock(ok=True)
+    mock_response.text = '{"test": "response"}'
+    mock_response.json.return_value = {"test": "response"}
+
+    monkeypatch.setattr(
+        'bigc.api_client.requests.request',
+        mock := MagicMock(return_value=mock_response),
+    )
+
+    return mock
+
+
+class TestRequest:
+    def test_retry_for_always_failing_endpoint(self, request_mock, dummy_request_client):
+        request_mock.side_effect = requests.RequestException()
+
+        with pytest.raises(BigCommerceNetworkError):
+            dummy_request_client.request('GET', '/test', retries=2)
+
+        assert request_mock.call_count == 3
+
+    def test_retry_eventually_succeeds(self, request_mock, dummy_request_client):
+        request_mock.side_effect = (requests.RequestException(), requests.RequestException(), request_mock.return_value)
+
+        dummy_request_client.request('GET', '/test', retries=2)
+
+        assert request_mock.call_count == 3

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -1,5 +1,5 @@
 from typing import Any, Iterator
-from unittest.mock import MagicMock
+from unittest.mock import create_autospec, MagicMock, Mock
 
 import pytest
 import requests
@@ -30,9 +30,7 @@ def dummy_request_client() -> DummyBigCommerceRequestClient:
 
 @pytest.fixture
 def request_mock(monkeypatch):
-    mock_response = MagicMock(ok=True)
-    mock_response.text = '{"test": "response"}'
-    mock_response.json.return_value = {"test": "response"}
+    mock_response = create_autospec(requests.Response)()
 
     monkeypatch.setattr(
         'bigc.api_client.requests.request',

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -49,9 +49,10 @@ class TestRequest:
 
         assert request_mock.call_count == 3
 
-    def test_retry_eventually_succeeds(self, request_mock, dummy_request_client):
+    @pytest.mark.parametrize('retries', [2, 3])
+    def test_retry_eventually_succeeds(self, request_mock, dummy_request_client, retries):
         request_mock.side_effect = (requests.RequestException(), requests.RequestException(), request_mock.return_value)
 
-        dummy_request_client.request('GET', '/test', retries=2)
+        dummy_request_client.request('GET', '/test', retries=retries)
 
         assert request_mock.call_count == 3


### PR DESCRIPTION
Resolves [FOO-1799](https://linear.app/medshift/issue/FOO-1799/add-retry-logic-and-request-options-timeout-retry-settings)

Ryan and I opted to not complicate this retry logic, not adding backoff or other settings. Retries are done automatically for GET requests with no delay. Retries only work for very specific errors (some 5xx, and network errors). 

Also, the other part of this issue (adding `timeout` param) was already tackled in a prior PR.