### PR TITLE
Support & Use Cursor Pagination Where Possible

### DIFF
--- a/bigc/api_client.py
+++ b/bigc/api_client.py
@@ -184,20 +184,16 @@ class BigCommerceV3APIClient(BigCommerceRequestClient):
         response = super().request(*args, **kwargs)
         return None if response is None else response['data']
 
-    def get_many(
+    def _get_many_using_limit_offset(
         self,
         path: str,
         *,
-        page_size: int | None = None,
-        params: dict[str, Any] | None = None,
-        timeout: float | None = None,
+        page_size: int,
+        params: dict[str, Any],
+        timeout: float | None,
     ) -> Iterator[Any]:
-        page_size = MAX_V3_PAGE_SIZE if page_size is None else int(page_size)
-
-        params = {**params} if params else {}
-
         if 'limit' in params or 'page' in params:
-            raise ValueError('params already has pagination values')
+            raise ValueError('params already has pagination values (limit and/or offset)')
 
         params['limit'] = page_size
 
@@ -215,3 +211,47 @@ class BigCommerceV3APIClient(BigCommerceRequestClient):
                 raise TypeError(f"expected list, got {type(res_data['data']).__name__}")
 
             yield from res_data['data']
+
+    def _get_many_using_cursor(
+        self,
+        path: str,
+        *,
+        page_size: int,
+        params: dict[str, Any],
+        timeout: float | None,
+    ) -> Iterator[Any]:
+        if 'limit' in params or 'after' in params:
+            raise ValueError('params already has pagination values (limit and/or after)')
+
+        params['limit'] = page_size
+
+        while True:
+            response = super().request('GET', path, params=params, timeout=timeout)
+
+            yield from response['data']
+
+            if not (
+                # end_cursor will still be provided if the next page is empty
+                response['meta']['cursor_pagination']['links'].get('next')
+                or response['data']
+            ):
+                break
+
+            params['after'] = response['meta']['cursor_pagination']['end_cursor']
+
+    def get_many(
+        self,
+        path: str,
+        *,
+        page_size: int | None = None,
+        params: dict[str, Any] | None = None,
+        timeout: float | None = None,
+        cursor: bool = False,
+    ) -> Iterator[Any]:
+        page_size = MAX_V3_PAGE_SIZE if page_size is None else int(page_size)
+        params = {**params} if params else {}
+
+        if cursor:
+            return self._get_many_using_cursor(path, page_size=page_size, params=params, timeout=timeout)
+        else:
+            return self._get_many_using_limit_offset(path, page_size=page_size, params=params, timeout=timeout)

--- a/bigc/api_client.py
+++ b/bigc/api_client.py
@@ -149,8 +149,8 @@ class BigCommerceV2APIClient(BigCommerceRequestClient):
 
         params = {**params} if params else {}
 
-        if 'limit' in params or 'page' in params:
-            raise ValueError('params already has pagination values')
+        if params.keys() & {'limit', 'offset'}:
+            raise ValueError('params already has pagination values (limit and/or offset)')
 
         params['limit'] = page_size
 
@@ -192,7 +192,7 @@ class BigCommerceV3APIClient(BigCommerceRequestClient):
         params: dict[str, Any],
         timeout: float | None,
     ) -> Iterator[Any]:
-        if 'limit' in params or 'page' in params:
+        if params.keys() & {'limit', 'offset'}:
             raise ValueError('params already has pagination values (limit and/or offset)')
 
         params['limit'] = page_size
@@ -220,7 +220,7 @@ class BigCommerceV3APIClient(BigCommerceRequestClient):
         params: dict[str, Any],
         timeout: float | None,
     ) -> Iterator[Any]:
-        if any(param in params for param in ('limit', 'before', 'after')):
+        if params.keys() & {'limit', 'before', 'after'}:
             raise ValueError('params already has pagination values (limit, before, and/or after)')
 
         params['limit'] = page_size

--- a/bigc/api_client.py
+++ b/bigc/api_client.py
@@ -220,8 +220,8 @@ class BigCommerceV3APIClient(BigCommerceRequestClient):
         params: dict[str, Any],
         timeout: float | None,
     ) -> Iterator[Any]:
-        if 'limit' in params or 'after' in params:
-            raise ValueError('params already has pagination values (limit and/or after)')
+        if any(param in params for param in ('limit', 'before', 'after')):
+            raise ValueError('params already has pagination values (limit, before, and/or after)')
 
         params['limit'] = page_size
 

--- a/bigc/api_client.py
+++ b/bigc/api_client.py
@@ -233,7 +233,7 @@ class BigCommerceV3APIClient(BigCommerceRequestClient):
             if not (
                 # end_cursor will still be provided if the next page is empty
                 response['meta']['cursor_pagination']['links'].get('next')
-                or response['data']
+                and response['data']
             ):
                 break
 

--- a/bigc/resources/customers_v3.py
+++ b/bigc/resources/customers_v3.py
@@ -10,7 +10,7 @@ class BigCommerceCustomersV3API:
 
     def all(self, *, params: dict[str, Any] | None = None, timeout: float | None = None) -> Iterator[dict[str, Any]]:
         """Return an iterator for all customers"""
-        return self._api.get_many('/customers', params=params, timeout=timeout)
+        return self._api.get_many('/customers', params=params, timeout=timeout, cursor=True)
 
     def get(
             self,

--- a/bigc/resources/product_categories_v3.py
+++ b/bigc/resources/product_categories_v3.py
@@ -7,7 +7,7 @@ class BigCommerceProductCategoriesV3API:
     def __init__(self, api: BigCommerceV3APIClient):
         self._api = api
 
-    def all_categories(
+    def all(
             self,
             *,
             params: dict[str, Any] | None = None,
@@ -16,18 +16,18 @@ class BigCommerceProductCategoriesV3API:
         """Return an iterator for all categories"""
         return self._api.get_many('/catalog/categories', params=params, timeout=timeout)
 
-    def get_category(self, category_id: int, *, timeout: float | None = None) -> dict[str, Any]:
+    def get(self, category_id: int, *, timeout: float | None = None) -> dict[str, Any]:
         """Get a specific category by its ID"""
         return self._api.get(f'/catalog/categories/{category_id}', timeout=timeout)
 
-    def create_category(self, data: dict[str, Any], timeout: float | None = None) -> dict[str, Any]:
+    def create(self, data: dict[str, Any], timeout: float | None = None) -> dict[str, Any]:
         """Create a category"""
         return self._api.post('/catalog/categories', data=data, timeout=timeout)
 
-    def update_category(self, category_id: int, data: dict[str, Any], timeout: float | None = None) -> dict[str, Any]:
+    def update(self, category_id: int, data: dict[str, Any], timeout: float | None = None) -> dict[str, Any]:
         """Update a specific category by its ID"""
         return self._api.put(f'/catalog/categories/{category_id}', data=data, timeout=timeout)
 
-    def delete_category(self, category_id: int, *, timeout: float | None = None) -> dict[str, Any]:
+    def delete(self, category_id: int, *, timeout: float | None = None) -> dict[str, Any]:
         """Delete a specific category by its ID"""
         return self._api.delete(f'/catalog/categories/{category_id}', timeout=timeout)


### PR DESCRIPTION
Resolves [FOO-1881](https://linear.app/medshift/issue/FOO-1881/use-cursor-pagination-where-possible)

I noticed I forgot to rename some of the methods on the product categories resource so I fixed that in https://github.com/MedShift/bigc/commit/bb195c9e94e088f4a368f0e7f6386f831c7a3b91

No v2 endpoints support cursor pagination. Also, the only endpoint in BigC that supports cursor pagination (I went through each one and tried) is customers.