### PR TITLE
Rename "Product Categories" -> "Categories"

### DIFF
--- a/bigc/api.py
+++ b/bigc/api.py
@@ -17,7 +17,7 @@ class BigCommerceAPI:
         self.orders_v2: BigCommerceOrdersV2API = BigCommerceOrdersV2API(api_v2)
         self.orders_v3: BigCommerceOrdersV3API = BigCommerceOrdersV3API(api_v3)
         self.pricing_v3: BigCommercePricingV3API = BigCommercePricingV3API(api_v3)
-        self.product_categories_v3: BigCommerceProductCategoriesV3API = BigCommerceProductCategoriesV3API(api_v3)
+        self.categories_v3: BigCommerceCategoriesV3API = BigCommerceCategoriesV3API(api_v3)
         self.product_variants_v3: BigCommerceProductVariantsV3API = BigCommerceProductVariantsV3API(api_v3)
         self.products_v3: BigCommerceProductsV3API = BigCommerceProductsV3API(api_v3)
         self.webhooks_v3: BigCommerceWebhooksV3API = BigCommerceWebhooksV3API(api_v3)

--- a/bigc/resources/__init__.py
+++ b/bigc/resources/__init__.py
@@ -11,7 +11,7 @@ from .customers_v3 import BigCommerceCustomersV3API
 from .orders_v2 import BigCommerceOrdersV2API
 from .orders_v3 import BigCommerceOrdersV3API
 from .pricing_v3 import BigCommercePricingV3API
-from .product_categories_v3 import BigCommerceProductCategoriesV3API
+from .categories_v3 import BigCommerceCategoriesV3API
 from .product_variants_v3 import BigCommerceProductVariantsV3API
 from .products_v3 import BigCommerceProductsV3API
 from .webhooks_v3 import BigCommerceWebhooksV3API

--- a/bigc/resources/categories_v3.py
+++ b/bigc/resources/categories_v3.py
@@ -3,7 +3,7 @@ from typing import Any, Iterator
 from bigc.api_client import BigCommerceV3APIClient
 
 
-class BigCommerceProductCategoriesV3API:
+class BigCommerceCategoriesV3API:
     def __init__(self, api: BigCommerceV3APIClient):
         self._api = api
 


### PR DESCRIPTION
This more closely follows the BigCommerce URL structure and it was unnecessary before to specify "products" because there is only one type of category in BigCommerce.