### PR TITLE
Add Missing `params=` Kwarg & Fix `add_consignments` Endpoint Method

### DIFF
--- a/bigc/resources/checkouts_v3.py
+++ b/bigc/resources/checkouts_v3.py
@@ -56,10 +56,10 @@ class BigCommerceCheckoutsV3API:
         """Update an existing billing address on a checkout"""
         return self._api.put(f'/checkouts/{checkout_id}/billing-address/{address_id}', data=data, timeout=timeout, retries=retries)
 
-    def add_consignment(
+    def add_consignments(
             self,
             checkout_id: UUIDLike,
-            data: dict[str, Any],
+            data: list[dict[str, Any]],
             *,
             params: dict[str, Any] | None = None,
             timeout: float | None = None,

--- a/bigc/resources/checkouts_v3.py
+++ b/bigc/resources/checkouts_v3.py
@@ -26,21 +26,23 @@ class BigCommerceCheckoutsV3API:
             checkout_id: UUIDLike,
             data: dict[str, Any],
             *,
+            params: dict[str, Any] | None = None,
             timeout: float | None = None,
             retries: int | None = None,
     ) -> dict[str, Any]:
         """Change customer message pertaining to an existing Checkout"""
-        return self._api.put(f'/checkouts/{checkout_id}', data=data, timeout=timeout, retries=retries)
+        return self._api.put(f'/checkouts/{checkout_id}', data=data, params=params, timeout=timeout, retries=retries)
 
     def add_billing_address(
             self,
             checkout_id: UUIDLike,
             data: dict[str, Any],
             *,
+            params: dict[str, Any] | None = None,
             timeout: float | None = None,
     ) -> dict[str, Any]:
         """Add a billing address to an existing checkout"""
-        return self._api.post(f'/checkouts/{checkout_id}/billing-address', data=data, timeout=timeout)
+        return self._api.post(f'/checkouts/{checkout_id}/billing-address', data=data, params=params, timeout=timeout)
 
     def update_billing_address(
             self,


### PR DESCRIPTION
Blocking [FOO-1848: Update Velocity To Use New BigC v1.0.0](https://linear.app/medshift/issue/FOO-1848/update-velocity-to-use-new-bigc-v100)

- I forgot to rename and fix the typing on `add_consignments`
- While undocumented, some endpoints actually do take `params` and are used within Velocity