### PR TITLE
Change publish workflow trigger to published

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,7 +2,7 @@ name: Publish
 
 on:
   release:
-    types: [ released ]
+    types: [ published ]
 
 jobs:
   publish-to-pypi:


### PR DESCRIPTION
Updates the release workflow to trigger when a prerelease is made. Previously I've had to make them as a normal release, then change it to a pre-release after publishing.

> The prereleased type will not trigger for pre-releases published from draft releases, but the published type will trigger. If you want a workflow to run when stable and pre-releases publish, subscribe to published instead of released and prereleased.
