### PR TITLE
Add connection pooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,13 +70,9 @@ bigcommerce.customers_v3.get(1, retries=5)
 
 ### Connection Pooling
 
-Requests are made through a [`requests.Session`], so connections are pooled and reused instead of reopened for each request. This needs no setup, and applies across both the v2 and v3 APIs, which share one session.
+Connections are pooled and reused instead of reopened for each request. This needs no setup, and applies across both the v2 and v3 APIs.
 
-The pool belongs to the `BigCommerceAPI` instance, so reuse a single instance rather than creating one per request. A `requests.Session` is not thread-safe, so each thread should use its own instance.
-
-The session is exposed as `bigcommerce.session` if you need to configure it, e.g. to `mount()` an adapter with a larger `pool_maxsize`. To reuse a session your application has already configured, pass it as `session`.
-
-[`requests.Session`]: https://requests.readthedocs.io/en/latest/user/advanced/#session-objects
+The pool belongs to the `BigCommerceAPI` instance, so reuse a single instance rather than creating one per request. Instances are safe to share between threads, and each thread gets its own pool.
 
 ### Direct API Access
 

--- a/README.md
+++ b/README.md
@@ -68,6 +68,16 @@ bigcommerce = BigCommerceAPI('store_hash', 'access_token', get_retries=2)
 bigcommerce.customers_v3.get(1, retries=5)
 ```
 
+### Connection Pooling
+
+Requests are made through a [`requests.Session`], so connections are pooled and reused instead of reopened for each request. This needs no setup, and applies across both the v2 and v3 APIs, which share one session.
+
+The pool belongs to the `BigCommerceAPI` instance, so reuse a single instance rather than creating one per request. A `requests.Session` is not thread-safe, so each thread should use its own instance.
+
+The session is exposed as `bigcommerce.session` if you need to configure it, e.g. to `mount()` an adapter with a larger `pool_maxsize`. To reuse a session your application has already configured, pass it as `session`.
+
+[`requests.Session`]: https://requests.readthedocs.io/en/latest/user/advanced/#session-objects
+
 ### Direct API Access
 
 For resources that aren't officially supported yet, `bigc` also includes a flexible API client that can be used to make direct requests to the BigCommerce API.

--- a/src/bigc/api.py
+++ b/src/bigc/api.py
@@ -1,3 +1,5 @@
+import requests
+
 from bigc.api_client import BigCommerceV2APIClient, BigCommerceV3APIClient
 from bigc.resources import *
 
@@ -9,10 +11,17 @@ class BigCommerceAPI:
             access_token: str,
             *,
             timeout: float | None = None,
-            get_retries: int | None = None
+            get_retries: int | None = None,
+            session: requests.Session | None = None,
     ):
-        api_v2 = BigCommerceV2APIClient(store_hash, access_token, timeout=timeout, get_retries=get_retries)
-        api_v3 = BigCommerceV3APIClient(store_hash, access_token, timeout=timeout, get_retries=get_retries)
+        self.session = session or requests.Session()
+
+        api_v2 = BigCommerceV2APIClient(
+            store_hash, access_token, timeout=timeout, get_retries=get_retries, session=self.session,
+        )
+        api_v3 = BigCommerceV3APIClient(
+            store_hash, access_token, timeout=timeout, get_retries=get_retries, session=self.session,
+        )
 
         self.api_v2 = api_v2
         self.api_v3 = api_v3

--- a/src/bigc/api.py
+++ b/src/bigc/api.py
@@ -1,4 +1,4 @@
-import requests
+import threading
 
 from bigc.api_client import BigCommerceV2APIClient, BigCommerceV3APIClient
 from bigc.resources import *
@@ -11,16 +11,16 @@ class BigCommerceAPI:
             access_token: str,
             *,
             timeout: float | None = None,
-            get_retries: int | None = None,
-            session: requests.Session | None = None,
+            get_retries: int | None = None
     ):
-        self.session = session or requests.Session()
+        # Shared so that both API versions use the same pool within a thread
+        thread_local = threading.local()
 
         api_v2 = BigCommerceV2APIClient(
-            store_hash, access_token, timeout=timeout, get_retries=get_retries, session=self.session,
+            store_hash, access_token, timeout=timeout, get_retries=get_retries, _thread_local=thread_local,
         )
         api_v3 = BigCommerceV3APIClient(
-            store_hash, access_token, timeout=timeout, get_retries=get_retries, session=self.session,
+            store_hash, access_token, timeout=timeout, get_retries=get_retries, _thread_local=thread_local,
         )
 
         self.api_v2 = api_v2

--- a/src/bigc/api_client.py
+++ b/src/bigc/api_client.py
@@ -1,4 +1,5 @@
 import itertools
+import threading
 from abc import ABC, abstractmethod
 from typing import Any, Iterator, NoReturn
 
@@ -25,13 +26,26 @@ class BigCommerceRequestClient(ABC):
             *,
             timeout: float | None = None,
             get_retries: int | None = None,
-            session: requests.Session | None = None,
+            _thread_local: threading.local | None = None,
     ):
         self.store_hash = store_hash
         self.access_token = access_token
         self.timeout = timeout
         self.get_retries = get_retries
-        self.session = session or requests.Session()
+        self._thread_local = _thread_local or threading.local()
+
+    @property
+    def _session(self) -> requests.Session:
+        """A session for the current thread
+
+        Sessions pool connections, but aren't thread-safe, so each thread gets
+        its own. Clients sharing a thread-local share a pool.
+        """
+        try:
+            return self._thread_local.session
+        except AttributeError:
+            self._thread_local.session = requests.Session()
+            return self._thread_local.session
 
     def request(
             self,
@@ -65,7 +79,7 @@ class BigCommerceRequestClient(ABC):
 
         def perform_request() -> Any:
             try:
-                response = self.session.request(
+                response = self._session.request(
                     method,
                     url,
                     json=data,

--- a/src/bigc/api_client.py
+++ b/src/bigc/api_client.py
@@ -24,12 +24,14 @@ class BigCommerceRequestClient(ABC):
             access_token: str,
             *,
             timeout: float | None = None,
-            get_retries: int | None = None
+            get_retries: int | None = None,
+            session: requests.Session | None = None,
     ):
         self.store_hash = store_hash
         self.access_token = access_token
         self.timeout = timeout
         self.get_retries = get_retries
+        self.session = session or requests.Session()
 
     def request(
             self,
@@ -63,7 +65,7 @@ class BigCommerceRequestClient(ABC):
 
         def perform_request() -> Any:
             try:
-                response = requests.request(
+                response = self.session.request(
                     method,
                     url,
                     json=data,

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,3 +1,5 @@
+import threading
+
 from bigc import BigCommerceAPI
 
 
@@ -5,5 +7,18 @@ class TestSession:
     def test_api_versions_share_one_session(self):
         api = BigCommerceAPI('store_hash', 'access_token')
 
-        assert api.api_v2.session is api.session
-        assert api.api_v3.session is api.session
+        assert api.api_v2._session is api.api_v3._session
+
+    def test_each_thread_gets_its_own_session(self):
+        api = BigCommerceAPI('store_hash', 'access_token')
+        sessions = []
+
+        threads = [threading.Thread(target=lambda: sessions.append(api.api_v2._session)) for _ in range(8)]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join()
+
+        assert len(sessions) == len(threads)
+        assert len(set(sessions)) == len(threads)
+        assert api.api_v2._session not in sessions

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,9 @@
+from bigc import BigCommerceAPI
+
+
+class TestSession:
+    def test_api_versions_share_one_session(self):
+        api = BigCommerceAPI('store_hash', 'access_token')
+
+        assert api.api_v2.session is api.session
+        assert api.api_v3.session is api.session

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -33,7 +33,8 @@ def request_mock(monkeypatch):
     mock_response = create_autospec(requests.Response)()
 
     monkeypatch.setattr(
-        'bigc.api_client.requests.request',
+        requests.Session,
+        'request',
         mock := MagicMock(return_value=mock_response),
     )
 


### PR DESCRIPTION
Closes SHIP-821

Requests now go through a `requests.Session` (created by default, shared between the v2 and v3 clients so they reuse one connection pool to the same host) instead of the module-level `requests.request`.

Pooling itself is `requests` behavior, and verifying real connection reuse would need a live socket, which isn't worth a test server here IMO. 